### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,18 +37,18 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-identify#readme",
   "devDependencies": {
-    "aegir": "^15.0.0",
-    "chai": "^4.1.2",
+    "aegir": "^17.1.1",
+    "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "pull-pair": "^1.1.0"
   },
   "dependencies": {
-    "multiaddr": "^5.0.0",
-    "peer-id": "~0.10.7",
+    "multiaddr": "^5.0.2",
+    "peer-id": "~0.12.0",
     "peer-info": "~0.14.1",
     "protons": "^1.0.1",
     "pull-length-prefixed": "^1.3.0",
-    "pull-stream": "^3.6.7"
+    "pull-stream": "^3.6.9"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",


### PR DESCRIPTION
We are having multiple versions of `peer-id` in`js-ipfs` bundle