### PR TITLE
feat: add protocol support to identify

### DIFF
--- a/src/dialer.js
+++ b/src/dialer.js
@@ -58,6 +58,9 @@ module.exports = (conn, expectedPeerInfo, callback) => {
           return callback(err)
         }
 
+        // Copy the protocols
+        peerInfo.protocols = new Set(input.protocols)
+
         callback(null, peerInfo, observedAddr)
       })
     })

--- a/src/listener.js
+++ b/src/listener.js
@@ -22,7 +22,8 @@ module.exports = (conn, pInfoSelf) => {
       agentVersion: 'na',
       publicKey: publicKey,
       listenAddrs: pInfoSelf.multiaddrs.toArray().map((ma) => ma.buffer),
-      observedAddr: observedAddrs ? observedAddrs.buffer : Buffer.from('')
+      observedAddr: observedAddrs ? observedAddrs.buffer : Buffer.from(''),
+      protocols: Array.from(pInfoSelf.protocols)
     })
 
     pull(

--- a/test/dialer.spec.js
+++ b/test/dialer.spec.js
@@ -33,12 +33,16 @@ describe('identify.dialer', () => {
   it('works', (done) => {
     const p = pair()
     original.multiaddrs.add(multiaddr('/ip4/127.0.0.1/tcp/5002'))
+    original.protocols.add('/echo/1.0.0')
+    original.protocols.add('/ping/1.0.0')
+
     const input = msg.encode({
       protocolVersion: 'ipfs/0.1.0',
       agentVersion: 'na',
       publicKey: original.id.pubKey.bytes,
       listenAddrs: [multiaddr('/ip4/127.0.0.1/tcp/5002').buffer],
-      observedAddr: multiaddr('/ip4/127.0.0.1/tcp/5001').buffer
+      observedAddr: multiaddr('/ip4/127.0.0.1/tcp/5001').buffer,
+      protocols: Array.from(original.protocols)
     })
 
     pull(
@@ -57,6 +61,44 @@ describe('identify.dialer', () => {
 
       expect(observedAddrs)
         .to.eql([multiaddr('/ip4/127.0.0.1/tcp/5001')])
+
+      expect(info.protocols).to.eql(original.protocols)
+
+      done()
+    })
+  })
+
+  it('should handle missing protocols', (done) => {
+    const p = pair()
+    original.multiaddrs.add(multiaddr('/ip4/127.0.0.1/tcp/5002'))
+
+    const input = msg.encode({
+      protocolVersion: 'ipfs/0.1.0',
+      agentVersion: 'na',
+      publicKey: original.id.pubKey.bytes,
+      listenAddrs: [multiaddr('/ip4/127.0.0.1/tcp/5002').buffer],
+      observedAddr: multiaddr('/ip4/127.0.0.1/tcp/5001').buffer,
+      protocols: Array.from(original.protocols)
+    })
+
+    pull(
+      values([input]),
+      lp.encode(),
+      p[0]
+    )
+
+    identify.dialer(p[1], (err, info, observedAddrs) => {
+      expect(err).to.not.exist()
+      expect(info.id.pubKey.bytes)
+        .to.eql(original.id.pubKey.bytes)
+
+      expect(info.multiaddrs.toArray())
+        .to.eql(original.multiaddrs.toArray())
+
+      expect(observedAddrs)
+        .to.eql([multiaddr('/ip4/127.0.0.1/tcp/5001')])
+
+      expect(Array.from(info.protocols)).to.eql([])
 
       done()
     })

--- a/test/listener.spec.js
+++ b/test/listener.spec.js
@@ -26,6 +26,9 @@ describe('identify.listener', () => {
         return done(err)
       }
 
+      _info.protocols.add('/echo/1.0.0')
+      _info.protocols.add('/chat/1.0.0')
+
       info = _info
       done()
     })
@@ -51,7 +54,7 @@ describe('identify.listener', () => {
           publicKey: info.id.pubKey.bytes,
           listenAddrs: [multiaddr('/ip4/127.0.0.1/tcp/5002').buffer],
           observedAddr: multiaddr('/ip4/127.0.0.1/tcp/5001').buffer,
-          protocols: []
+          protocols: ['/echo/1.0.0', '/chat/1.0.0']
         })
         done()
       })


### PR DESCRIPTION
This adds support for exchanging protocols via the identify protocol. The protobuf was already configured to support protocols, but they were not being added or retrieved from the message. This resolves that.

Required by https://github.com/libp2p/js-libp2p-switch/pull/311