### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 [![](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-identify.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-identify)
 [![](https://img.shields.io/travis/libp2p/js-libp2p-identify.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-identify)
 [![Dependency Status](https://david-dm.org/libp2p/js-libp2p-identify.svg?style=flat-square)](https://david-dm.org/libp2p/js-libp2p-identify)

--- a/package.json
+++ b/package.json
@@ -41,17 +41,17 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-identify#readme",
   "devDependencies": {
-    "aegir": "^18.1.0",
+    "aegir": "^18.2.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "pull-pair": "^1.1.0"
   },
   "dependencies": {
-    "multiaddr": "^6.0.4",
+    "multiaddr": "^6.0.6",
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1",
     "protons": "^1.0.1",
-    "pull-length-prefixed": "^1.3.1",
+    "pull-length-prefixed": "^1.3.2",
     "pull-stream": "^3.6.9"
   },
   "contributors": [


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated