### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+⛔️ DEPRECATED: libp2p-identify is now included in js-libp2p
+=====
+
 # js-libp2p-identify
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)


### PR DESCRIPTION
DEPRECATED: Identify is now part of the js-libp2p repo.